### PR TITLE
handle key not found error

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,6 +166,10 @@ func getSecretsFromVault() ([]token, error) {
 			return nil, fmt.Errorf("Unable to read from key %q: %s", k, err)
 		}
 
+		if data == nil {
+			return nil, fmt.Errorf("Key %q not found", k)
+		}
+
 		if data.Data[cfg.Field] == nil {
 			return nil, fmt.Errorf("The key %q does not have a field named %q.", k, cfg.Field)
 		}


### PR DESCRIPTION
If a key is not found client.Logical().Read(k) will return (nil, nil).
Lets gracefully handle this case and tell the user what is wrong.